### PR TITLE
inject: check first if Vue prototype key exists.

### DIFF
--- a/packages/@uvue/core/lib/initApp.js
+++ b/packages/@uvue/core/lib/initApp.js
@@ -26,7 +26,10 @@ export default async (options, context) => {
   // Inject function
   const inject = (key, value) => {
     if (!/^\$/.test(key)) key = `$${key}`;
-    context[key] = Vue.prototype[key] = value;
+    context[key] = value;
+    if (!Object.prototype.hasOwnProperty.call(Vue.prototype, key)) {
+      Vue.prototype[key] = value;
+    }
     if (options.store) {
       options.store[key] = value;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Function `inject` uses prototype for Vue to inject a new object without to check if the key already exists.

**What is the current behavior?**

No property check before inject new object. Results in an error.

**What is the new behavior?**

Function inject tests if the key already exists in Vue. If the key exists, adding is skipped for Vue object.

**Checklist**:
- [ ] Documentation
- [ ] Tests
